### PR TITLE
feat(nx-cloud): set up nx workspace

### DIFF
--- a/nx.json
+++ b/nx.json
@@ -17,12 +17,7 @@
     { "plugin": "./tools/nx-tsdown" },
     { "plugin": "./tools/nx-tsgo" },
     { "plugin": "./tools/nx-vitest" },
-    {
-      "plugin": "@nx/eslint/plugin",
-      "options": {
-        "targetName": "lint"
-      }
-    }
+    { "plugin": "@nx/eslint/plugin", "options": { "targetName": "lint" } }
   ],
   "targetDefaults": {
     "@nx/js:swc": {
@@ -30,12 +25,8 @@
       "dependsOn": ["^build"],
       "inputs": ["production", "^production"]
     },
-    "test": {
-      "dependsOn": ["^build"]
-    },
-    "nx-release-publish": {
-      "dependsOn": ["build", "lint"]
-    },
+    "test": { "dependsOn": ["^build"] },
+    "nx-release-publish": { "dependsOn": ["build", "lint"] },
     "release": {
       "executor": "./tools/nx-release:release",
       "options": {
@@ -61,28 +52,19 @@
       "types": {
         "docs": {
           "semverBump": "patch",
-          "changelog": {
-            "title": "📖 Documentation",
-            "hidden": false
-          }
+          "changelog": { "title": "📖 Documentation", "hidden": false }
         }
       }
     },
     "changelog": {
-      "workspaceChangelog": {
-        "createRelease": false,
-        "file": false
-      },
+      "workspaceChangelog": { "createRelease": false, "file": false },
       "projectChangelogs": {
         "createRelease": false,
         "file": "{projectRoot}/CHANGELOG.md"
       }
     },
-    "version": {
-      "conventionalCommits": true
-    }
+    "version": { "conventionalCommits": true }
   },
-  "tui": {
-    "enabled": false
-  }
+  "tui": { "enabled": false },
+  "nxCloudId": "68e7aec08c2fc3d55914bb10"
 }


### PR DESCRIPTION
feat(nx-cloud): setup nx cloud workspace

This commit sets up Nx Cloud for your Nx workspace, enabling distributed caching and the Nx Cloud GitHub integration for fast CI and improved developer experience.

You can access your Nx Cloud workspace by going to
https://cloud.nx.app/orgs/68e17ef767af86a2c0c23c29/workspaces/68e7aec08c2fc3d55914bb10

**Note:** This commit attempts to maintain formatting of the nx.json file, however you may need to correct formatting by running an nx format command and committing the changes.